### PR TITLE
more meaningul error message

### DIFF
--- a/lib/serverController.js
+++ b/lib/serverController.js
@@ -92,7 +92,7 @@ module.exports = function() {
       var log = logDir + '/' + server.replace('nscale-', '') + '.log';
       var cmd = 'exec ' + server + ' -c ' + config + ' > ' + log + ' 2>&1';
       var child = exec(cmd, { stdio: 'inherit' }, function(err, stdout, stderr) {
-        if (err) { cb(err); }
+        if (err) { cb('server failed to start. run `nscale log` for more information'); }
       });
       cb(null, child);
     };


### PR DESCRIPTION
This error occurs when we attempt the boot the kernel with a port that is already in use. The newer error tells the user to check `nscale log` where they can clearly see the "EADDRINUSE" log