### PR TITLE
fix config error

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -61,7 +61,7 @@ var getKernelPort = function() {
     config = JSON.parse(config);
   }
 
-  return config ? config.kernel.port : DEFAULT_PORT;
+  return config.kernel.port || DEFAULT_PORT;
 }
 
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -26,7 +26,7 @@ var DEFAULT_PORT = 3223;
 
 
 exports.writeBlankConfig = function() {
-  var kernelPort = getGlobalConfig().kernel.port || DEFAULT_PORT;
+  var kernelPort = getKernelPort();
   var config = {use: 'localhost', targets: { localhost: {host: 'localhost', port: kernelPort}}};
   fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2), 'utf8');
   return config;
@@ -42,10 +42,7 @@ var loadConfig = function() {
   } else {
     config = fs.readFileSync(CONFIG_PATH, 'utf8');
     config = JSON.parse(config);
-    if (!config.targets[config.use].port) {
-      config.targets[config.use].port = getGlobalConfig().kernel.port
-          || DEFAULT_PORT;
-    }
+    config.targets[config.use].port = getKernelPort();
     saveConfig(config);
   }
   return config;
@@ -57,20 +54,14 @@ var saveConfig = function(config) {
   fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2), 'utf8');
 };
 
-var getGlobalConfig = function() {
+var getKernelPort = function() {
   var config = null;
-
   if (fs.existsSync(GLOBAL_CONFIG)) {
     config = fs.readFileSync(GLOBAL_CONFIG);
     config = JSON.parse(config);
-    config.kernel = config.kernel || {};
-  } else {
-    throw new Error('No nscale-client config file found.\n' +
-        '  Expected to see one at ' + GLOBAL_CONFIG + '\n' +
-        '  Have you started nscale (I.E. nscale start)?');
   }
 
-  return config;
+  return config ? config.kernel.port : DEFAULT_PORT;
 }
 
 


### PR DESCRIPTION
This means we do not need to throw an error anymore.

The old way of writing a blank `.nearform` config file completely depended on `~/.nscale/config/config.json` already existing. This was a bug introduced on my part.

Instead, if the global config doesn't exist, we just write the default port number to the `~/.nearform` file. If the global config **does** exist we always make sure to update the `~/.nearform` file with the port number in there.

The newly written tests now fail as errors are not thrown anymore. @mcollina what do you think I should do with that?
